### PR TITLE
Adds ctrl+p vim plugin for fuzzy open ability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -97,3 +97,6 @@
 [submodule "home/.vim/bundle/csv.vim"]
 	path = home/.vim/bundle/csv.vim
 	url = git://github.com/chrisbra/csv.vim.git
+[submodule "home/.vim/bundle/ctrlp.vim"]
+	path = home/.vim/bundle/ctrlp.vim
+	url = git@github.com:kien/ctrlp.vim.git


### PR DESCRIPTION
Ctrl+P is a popular vim plugin that enables you to open a filename when you only know (or only feel like typing) a fragment of the full pathname. This shouldn't break anything, just add this new feature

usage:
- [ctrl]+[p] to open it
- type document name fragments
- [ctrl]+[j] or [ctrl]+[k] to choose one
- [ctrl]+[t] to open in a new tab (etc)

see their page for details
https://github.com/kien/ctrlp.vim
