### PR TITLE
add -b parameter to rsp since default will change in rails 4.2 to localhost

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -93,7 +93,7 @@ export NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 if [ -f "$HOME/.my_pairing_port" ]; then
   # Put your pairing port in ~/.my_pairing_port (single line with just your port number)
   my_pairing_port=$(cat $HOME/.my_pairing_port)
-  alias rsp="rails server --port ${my_pairing_port} puma"
+  alias rsp="rails server --port ${my_pairing_port} -b 0.0.0.0 puma"
 fi
 
 allied_rsp() {


### PR DESCRIPTION
- This is a good thing in general
- See http://edgeguides.rubyonrails.org/4_2_release_notes.html#default-host-for-rails-server
- This still works because `-b`'s default is `0.0.0.0`
