### PR TITLE
map RenameFile() vim function to <leader>mv

### DIFF
--- a/home/.vimrc
+++ b/home/.vimrc
@@ -116,6 +116,19 @@ map <Leader>9 :.s/:\([_a-z0-9]\{1,}\) *=>/\1:/g<CR>:nohlsearch<CR>
 " paste
 map <leader>v :set paste!<CR>
 
+" Rename current file. Hit enter after adjusting file name. Will reload vim
+" buffer
+function! RenameFile()
+    let old_name = expand('%')
+    let new_name = input('New file name: ', expand('%'))
+    if new_name != '' && new_name != old_name
+      exec ':saveas ' . new_name
+      exec ':silent !rm ' . old_name
+      redraw!
+    endif
+endfunction
+map <leader>mv :call RenameFile()<cr>
+
 abbrev teh the
 abbrev yuo you
 abbrev hte the


### PR DESCRIPTION
Added a function to the dotfiles that will allow you to rename a file "in-place" in vim. You adjust the file name, hit enter, and it will do the mv for you and reload your buffer. I mapped it to <leader>mv because I thought that made the most sense, but let me know if there are better ideas.
