### PR TITLE
Add 2 Ruby refactorings to .vimrc

### DIFF
--- a/home/.vimrc
+++ b/home/.vimrc
@@ -98,6 +98,13 @@ map \ :NERDTreeToggle<CR>
 map <Leader>p gg:s/\s*$<CR>/\d\+-<CR>ywggA [#<esc>pa]<esc>
 nmap <Leader>l iLorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.<esc>
 
+
+" Turn `x = expr` into `let(:x) { expr }`, via comma-"let"
+nmap <Leader>let Ilet(:<esc>ea)<esc>f=r{A }<esc>
+
+" Select some ruby, comma-"var", and it'll extract a local variable.
+vmap <Leader>var cyour_variable<esc>Oyour_variable = <esc>p0*
+
 if filereadable(glob("~/.vimrc.local"))
   source ~/.vimrc.local
 endif


### PR DESCRIPTION
Add <Leader>var to introduce a local-var from an expression, and <Leader>let to turn a local-var into a `let`.
