### PR TITLE
Page up and Page down for scroll history

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -14,3 +14,7 @@ set -g update-environment "DISPLAY SSH_ASKPASS SSH_AGENT_PID SSH_CONNECTION WIND
 set-environment -g 'SSH_AUTH_SOCK' ~/.ssh/ssh_auth_sock
 
 set -g history-limit 10000
+# Ctrl+D/Ctrl+U(PageDown/Up) in the tmux scroll mode.  see http://stackoverflow.com/questions/14300684/tmux-scroll-up-down-page-using-ctrl-b-and-ctrl-f
+# also you can use / for searching
+bind-key -t vi-edit Up   history-up
+bind-key -t vi-edit Down history-down


### PR DESCRIPTION
After you're in tmux history via CTRL+[

It's nice to be able to page up and page down. This key mapping adds (first switch into scroll history `CTRL+[` then.
- Page up CTRL+U
- Page down CTRL+D 

Also I didn't realize if you want to search in history you can use `/` because of vi-everywhere.
