### PR TITLE
Add command to open all modified but unstaged work in vim tabs

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -80,6 +80,7 @@ hitch() {
 }
 alias unhitch='hitch -u'
 alias vi='vim'
+alias openwork='vim -p $(git ls-files -m)'
 
 # Uncomment to persist pair info between terminal instances
 echo "-----"


### PR DESCRIPTION
Here is a cool command Dan, Tom, and I worked on together to open all of the files you have unstaged in separate vim tabs. A good use case for this would be if you are popping a stash, and you want to immediately open everything that was modified in the stash. (Also pairs well with git-gutter to see what happened in the files).

We cool with this?
