### PR TITLE
Pivotal hotfix creation from the cli

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ gem 'homesick'
 gem 'hitch'
 gem 'scss-lint'
 gem 'thyme'
+
+# stuff for pivotal
+gem 'activesupport'
+gem 'faraday', '~> 0.9.0'
+gem 'tracker_api', '0.2.9' # this is the minimum version for creating pivotal stories and depends on faraday 0.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,41 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (4.2.1)
+      activesupport (= 4.2.1)
+      builder (~> 3.1)
+    activesupport (4.2.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.3.8)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
+    builder (3.2.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    equalizer (0.0.11)
+    excon (0.45.3)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.9.1)
+      faraday (>= 0.7.4, < 0.10)
     highline (1.7.1)
     hitch (1.0.2)
       highline (>= 1.6.2)
     homesick (1.1.2)
       thor (>= 0.14.0)
+    i18n (0.7.0)
+    ice_nine (0.11.1)
+    json (1.8.2)
+    minitest (5.6.1)
+    multipart-post (2.0.0)
     rainbow (2.0.0)
     ruby-progressbar (1.7.5)
     sass (3.4.13)
@@ -13,14 +43,33 @@ GEM
       rainbow (~> 2.0)
       sass (~> 3.4.1)
     thor (0.19.1)
+    thread_safe (0.3.5)
     thyme (0.0.14)
       ruby-progressbar
+    tracker_api (0.2.9)
+      activemodel
+      activesupport
+      addressable
+      excon
+      faraday (~> 0.9.0)
+      faraday_middleware
+      virtus
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
+  faraday (~> 0.9.0)
   hitch
   homesick
   scss-lint
   thyme
+  tracker_api (= 0.2.9)

--- a/home/.bin/create-hotfix
+++ b/home/.bin/create-hotfix
@@ -15,8 +15,8 @@ if !uncommitted_files.empty?
 end
 
 story_name = ARGV[0]
-project_id = env['PIVOTAL_PROJECT_ID']
-pivotal_token = env['PIVOTAL_TOKEN']
+project_id = ENV['PIVOTAL_PROJECT_ID']
+pivotal_token = ENV['PIVOTAL_TOKEN']
 
 if story_name.nil? || story_name.empty?
   raise ArgumentError, "please pass a pivotal story name"

--- a/home/.bin/create-hotfix
+++ b/home/.bin/create-hotfix
@@ -23,11 +23,11 @@ if story_name.nil? || story_name.empty?
 end
 
 if project_id.nil? || project_id.empty?
-  raise ArgumentError, "You need to populate the PIVOTAL_TOKEN environment variable (probably in ~/.zsh/control-rails.zsh)"
+  raise ArgumentError, "You need to populate the PIVOTAL_PROJECT_ID environment variable"
 end
 
 if pivotal_token.nil? || pivotal_token.empty?
-  raise ArgumentError, "You need to populate the PIVOTAL_TOKEN environment variable (probably in ~/.zsh/control-rails.zsh)"
+  raise ArgumentError, "You need to populate the PIVOTAL_TOKEN environment variable"
 end
 
 hitch_config = YAML.load_file("#{ENV['HOME']}/.hitchrc")

--- a/home/.bin/create-hotfix
+++ b/home/.bin/create-hotfix
@@ -4,6 +4,37 @@ require 'tracker_api'
 require 'yaml'
 require 'active_support'
 
+### What it does
+# We created a script that will create a bug pivotal story and start a hotfix branch for you. All you need to do is pass a story name.
+
+# Setting it up
+#   If you want to use it, you have to add your Pivotal API Key as an
+#   environment variable. On my account, I put it in ~/.zsh/control-rails.zsh.
+#   (but all files in ~/.zsh our loaded so put it any file in that directory)
+#
+#   This script can also detect if you are "hitched" with someone using the
+#   hitch gem (it reads ~/.hitchrc). If you don't hitch the Pivotal card will
+#   be assigned to $USER (note your Pivotal user needs to match your unix user
+#   in this case)
+
+# i.e.
+#    export PIVOTAL_TOKEN="TOKEN HERE"
+#    export PIVOTAL_PROJECT_ID="some_number_here"
+#
+#    You can find your token at the bottom of the User Profile page on Pivotal,
+#    which you can get to by clicking your name in the top right corner.
+#
+# How you'd use it
+#     i.e. script/create-hotfix 'Do The Needful'
+#
+# What it does
+#
+# It will detect who you are hitched with and add both as story owners. It won't
+# run if you have unstaged git changes. It will then create the branch name using
+# the slugify pivotal card bookmarklet logic.
+#
+####
+
 # trolling
 class GitError < StandardError; end
 

--- a/home/.bin/create-hotfix
+++ b/home/.bin/create-hotfix
@@ -70,15 +70,15 @@ story_owners = if hitch_config[:current_pair].empty?
 
 client = TrackerApi::Client.new(token: pivotal_token)
 # we only have one project so this works well
-control = client.project(project_id)
+project = client.project(project_id)
 
-pivotal_users = control.memberships.map(&:person).select do |person|
+pivotal_users = project.memberships.map(&:person).select do |person|
   story_owners.include? person.email.split("@").first
 end
 
 pivotal_ids = pivotal_users.map(&:id)
 
-story = control.create_story(name: story_name, story_type: 'bug', current_state: 'started', owner_ids: pivotal_ids)
+story = project.create_story(name: story_name, story_type: 'bug', current_state: 'started', owner_ids: pivotal_ids)
 
 puts "Your pivotal story is https://www.pivotaltracker.com/story/show/#{story.id}"
 

--- a/home/.bin/create-hotfix
+++ b/home/.bin/create-hotfix
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+require 'shellwords'
+require 'tracker_api'
+require 'yaml'
+require 'active_support'
+
+# trolling
+class GitError < StandardError; end
+
+#check for uncommitted git files because git-flow will blow up
+uncommitted_files = `git status --porcelain`
+
+if !uncommitted_files.empty?
+  raise GitError, "you have uncommitted changes"
+end
+
+story_name = ARGV[0]
+project_id = env['PIVOTAL_PROJECT_ID']
+pivotal_token = env['PIVOTAL_TOKEN']
+
+if story_name.nil? || story_name.empty?
+  raise ArgumentError, "please pass a pivotal story name"
+end
+
+if project_id.nil? || project_id.empty?
+  raise ArgumentError, "You need to populate the PIVOTAL_TOKEN environment variable (probably in ~/.zsh/control-rails.zsh)"
+end
+
+if pivotal_token.nil? || pivotal_token.empty?
+  raise ArgumentError, "You need to populate the PIVOTAL_TOKEN environment variable (probably in ~/.zsh/control-rails.zsh)"
+end
+
+hitch_config = YAML.load_file("#{ENV['HOME']}/.hitchrc")
+story_owners = if hitch_config[:current_pair].empty?
+                 Array(ENV['USER'])
+               else
+                 hitch_config[:current_pair]
+               end
+
+client = TrackerApi::Client.new(token: pivotal_token)
+# we only have one project so this works well
+control = client.project(project_id)
+
+pivotal_users = control.memberships.map(&:person).select do |person|
+  story_owners.include? person.email.split("@").first
+end
+
+pivotal_ids = pivotal_users.map(&:id)
+
+story = control.create_story(name: story_name, story_type: 'bug', current_state: 'started', owner_ids: pivotal_ids)
+
+puts "Your pivotal story is https://www.pivotaltracker.com/story/show/#{story.id}"
+
+slugified_story_name = story_name.parameterize
+
+puts "Creating hotfix branch for #{story_name}"
+escaped_hotfix_name = Shellwords.shellescape("#{story.id}-#{slugified_story_name}")
+`git flow hotfix start #{escaped_hotfix_name}`

--- a/home/.bin/git-flow-rebase
+++ b/home/.bin/git-flow-rebase
@@ -1,0 +1,13 @@
+string=`git symbolic-ref HEAD`;
+
+if [[ "$string" == "refs/heads/feature/"* ]]
+then
+  echo "Rebasing this feature on develop";
+  git co develop && git pull && git co - && git rebase develop
+elif [[ "$string" == "refs/heads/hotfix/"* ]]
+then
+  echo "Rebasing this hotfix on master";
+  git co master && git pull && git co - && git rebase master
+else
+  echo "Not rebasing, this is neither a hotfix nor a feature.";
+fi

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -90,6 +90,7 @@ echo "-----"
 
 PATH=$PATH:$HOME/.rvm/bin # Add RVM to PATH for scripting
 PATH=$PATH:$HOME/bin # Make personal scripts available
+PATH=$PATH:$PWD/home/.bin # Make personal scripts available
 
 # tell nokogiri to use sysem libraries instead of compiling packaged libs
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=1

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -90,7 +90,7 @@ echo "-----"
 
 PATH=$PATH:$HOME/.rvm/bin # Add RVM to PATH for scripting
 PATH=$PATH:$HOME/bin # Make personal scripts available
-PATH=$PATH:$PWD/home/.bin # Make personal scripts available
+PATH=$PATH:$HOME/.homesick/repos/dotfiles/home/.bin # Make personal scripts available
 
 # tell nokogiri to use sysem libraries instead of compiling packaged libs
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=1


### PR DESCRIPTION
originally from pull/106#issuecomment-102415174
# What it does

We created a script that will create a bug pivotal story and start a hotfix branch for you. All you need to do is pass a story name.
# Setting it up

If you want to use it, you have to add your Pivotal API Key as an environment variable. On my account, I put it in ~/.zsh/control-rails.zsh. (but all files in ~/.zsh our loaded so put it any file in that directory)

i.e. 

```
export PIVOTAL_TOKEN="TOKEN HERE"
export PIVOTAL_PROJECT_ID="some_number_here"
```

You can find your token at the bottom of the User Profile page on Pivotal, which you can get to by clicking your name in the top right corner.

Before using, make sure to source the control-rails file so the variable loads in, or start a new session.
# How you'd use it

i.e. script/create-hotfix 'Do The Needful'
# What it does

It will detect who you are hitched with and add both as story owners. It won't run if you have unstaged git changes. It will then create the branch name using the slugify pivotal card bookmarklet logic (thanks Casey!).
# Misc
- This also adds the .bin directory in this repo to your path.
- This also moves git-flow-rebase from the control repo into this repo (as it's not rails related)
