### PR TITLE
Update status bar on pomodoro

### DIFF
--- a/home/.thymerc
+++ b/home/.thymerc
@@ -44,6 +44,6 @@ end
 
 after do |seconds_left|
   if @tmux
-    `tmux set-option -g status-bg red`
+    `tmux set-option -g status-bg magenta`
   end
 end

--- a/home/.thymerc
+++ b/home/.thymerc
@@ -34,10 +34,16 @@ option :m, 'minutes num', 'run with custom minutes' do |num|
   run
 end
 
-# before do
-#   `mplayer ~/music/flight-of-the-bumble-bee.mp3 &`
-# end
+option :r, :reset, 'reset status bar' do
+  `tmux set-option -g status-bg black`
+end
+
+before do
+  `tmux set-option -g status-bg black`
+end
 
 after do |seconds_left|
-  `notify-send -u critical "Thyme's Up!"` if seconds_left == 0
+  if @tmux
+    `tmux set-option -g status-bg red`
+  end
 end


### PR DESCRIPTION
In response to some feedback received on the tmux pomodoro timer, I made this update to change the color of the status bar when a timer finishes. Restarting a timer will change the status bar color back to black (maybe should have done default?). 

Some problems I've seen with this (which may or may not affect people)
- The yellow highlight on your current tab disappears when the bar is red
- Guard's status colors to the tmux session name do not appear when the bar is red.

Please let me know your feedback.

Here's an image of the status bar after a pomodoro
![image](https://cloud.githubusercontent.com/assets/1148933/7947392/6ca7f974-0942-11e5-9750-2b4fe8c0d3e9.png)

Here's what the screen looks like with the highlighted window name and session name. Notice those are not highlighted when the status bar changes color after a pomodoro.

![image](https://cloud.githubusercontent.com/assets/1148933/7947444/d7ff36e2-0942-11e5-93b4-d8bf6b98f99d.png)

Trish
