### PR TITLE
Add shared git configuration for tagging hotfix branches

### DIFF
--- a/home/.gitconfig.d/shared
+++ b/home/.gitconfig.d/shared
@@ -17,6 +17,8 @@
   preloadindex = true
 [gitflow.hotfix "finish"]
   message = "hotfix"
+[gitflow.release "finish"]
+  message = "release"
 [merge]
   tool = /usr/bin/vimdiff
 [push]

--- a/home/.gitconfig.d/shared
+++ b/home/.gitconfig.d/shared
@@ -15,6 +15,8 @@
   pager = "less -F -X"
   editor = /usr/bin/vim
   preloadindex = true
+[gitflow.hotfix "finish"]
+  message = "hotfix"
 [merge]
   tool = /usr/bin/vimdiff
 [push]


### PR DESCRIPTION
This will save us the trouble of manually typing this exact same tag in
the editor every time we finish a hotfix.
