### PR TITLE
Adds git wip commands

### DIFF
--- a/home/.bin/git-unwip-it
+++ b/home/.bin/git-unwip-it
@@ -1,0 +1,1 @@
+git reset --soft HEAD~ && git reset

--- a/home/.bin/git-wip-it
+++ b/home/.bin/git-wip-it
@@ -1,0 +1,1 @@
+git add . && git ci -m "[skip ci] wip"


### PR DESCRIPTION
This PR adds two commands:

`git wip-it`
and
`git unwip-it`

you know, for when a problem comes along

![You must whip it](http://media.giphy.com/media/4zR6rfZ6djKW4/giphy.gif)

the first, adds _everything_ and commits it with this message `[skip ci] wip`

the second soft resets the second command and then resets again to unstage

The only thing I can think of that might make this better is if the second command would blow up if the most recent commit message didn't include the word wip

@jhirbour @benjaminoakes @danbernier @tlball @jnimety :eyeglasses: :thought_balloon: s?
