### PR TITLE
faster fuzzy open ctrl p

### DIFF
--- a/home/.vimrc
+++ b/home/.vimrc
@@ -174,4 +174,5 @@ let g:gitgutter_sign_column_always = 1
 " Re-indent the whole file and go back to where you were
 map <leader>= gg=G''
 
+" don't load everything in .git into the ctrl-p buffer
 let g:ctrlp_user_command = ['.git/', 'git --git-dir=%s/.git ls-files -oc --exclude-standard']

--- a/home/.vimrc
+++ b/home/.vimrc
@@ -175,4 +175,5 @@ let g:gitgutter_sign_column_always = 1
 map <leader>= gg=G''
 
 " don't load everything in .git into the ctrl-p buffer
+" source: https://medium.com/a-tiny-piece-of-vim/making-ctrlp-vim-load-100x-faster-7a722fae7df6
 let g:ctrlp_user_command = ['.git/', 'git --git-dir=%s/.git ls-files -oc --exclude-standard']

--- a/home/.vimrc
+++ b/home/.vimrc
@@ -173,3 +173,5 @@ let g:gitgutter_sign_column_always = 1
 
 " Re-indent the whole file and go back to where you were
 map <leader>= gg=G''
+
+let g:ctrlp_user_command = ['.git/', 'git --git-dir=%s/.git ls-files -oc --exclude-standard']


### PR DESCRIPTION
By default `ctrlP` searches through all the files in the current directory, including hidden directories. We'd rather not have `ctrlP` waste its time wading through the `.git` folder and `gitignored` files. This makes the first run of `ctrlP` in a session run 100x faster :D

https://medium.com/a-tiny-piece-of-vim/making-ctrlp-vim-load-100x-faster-7a722fae7df6
