### PR TITLE
add an experimental tabs layout loading with [tmuxleader]+[s]

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -74,3 +74,8 @@ set-option -g display-panes-colour brightblue
 
 # clock
 set-window-option -g clock-mode-colour yellow
+
+
+# a tmux tabs layout with vim&guard
+# idea inspired by http://stackoverflow.com/questions/5609192/how-to-set-up-tmux-so-that-it-starts-up-with-specified-windows-opened
+bind s source-file ~/.tmux/session1

--- a/home/.tmux/session1
+++ b/home/.tmux/session1
@@ -14,8 +14,8 @@ neww -n git
 # tab 4 is for other things
 neww
 
-# make window 2 the alternate one
-# and window 0 left pane the one we end up on at the end
+# make window 2's left pane the alternate one
+# and window 0 the one we end up on at the end
 selectw -t 2
 selectp -t 0
 selectw -t 0

--- a/home/.tmux/session1
+++ b/home/.tmux/session1
@@ -1,5 +1,5 @@
 # window 0 is for rsp
-# neww -n rsp
+rename-window server
 
 # window 1 is for rails console
 neww -n console 'rails c'

--- a/home/.tmux/session1
+++ b/home/.tmux/session1
@@ -1,8 +1,19 @@
-neww -n rsp
+# tab 0 is for rsp
+# neww -n rsp
+
+# tab 1 is for rails console
 neww -n console 'rails c'
+
+# tab 2 is a split, vim is 70% on left, guard is 30% on right
 neww -n vim&guard vim
 splitw -h -p30 guard
+
+# tab 3 is for git
 neww -n git
+
+# tab 4 is for other things
 neww
+
+# make pane 2 the alternate one, and pane 0 the one we end up on at the end
 selectw -t 2
 selectw -t 0

--- a/home/.tmux/session1
+++ b/home/.tmux/session1
@@ -1,17 +1,17 @@
-# tab 0 is for rsp
+# window 0 is for rsp
 # neww -n rsp
 
-# tab 1 is for rails console
+# window 1 is for rails console
 neww -n console 'rails c'
 
-# tab 2 is a split, vim is 70% on left, guard is 30% on right
+# window 2 is a split, vim is 70% on left, guard is 30% on right
 neww -n vim&guard vim
 splitw -h -p30 guard
 
-# tab 3 is for git
+# window 3 is for git
 neww -n git
 
-# tab 4 is for other things
+# window 4 is for other things
 neww
 
 # make window 2's left pane the alternate one

--- a/home/.tmux/session1
+++ b/home/.tmux/session1
@@ -14,6 +14,8 @@ neww -n git
 # tab 4 is for other things
 neww
 
-# make pane 2 the alternate one, and pane 0 the one we end up on at the end
+# make window 2 the alternate one
+# and window 0 left pane the one we end up on at the end
 selectw -t 2
+selectp -t 0
 selectw -t 0

--- a/home/.tmux/session1
+++ b/home/.tmux/session1
@@ -1,0 +1,8 @@
+neww -n rsp
+neww -n console 'rails c'
+neww -n vim&guard vim
+splitw -h -p30 guard
+neww -n git
+neww
+selectw -t 2
+selectw -t 0


### PR DESCRIPTION
(work in progress)

This PR would help us start a wemux session quickly, auto-opening the tabs we always end up opening anyway. Inspired by [this SO post](http://stackoverflow.com/questions/5609192/how-to-set-up-tmux-so-that-it-starts-up-with-specified-windows-opened).

This will:
- indirectly reduce the amount of wrong-hitch errors (since a lot come from `unhitch`ing in only one of the wemux tabs)
- make it more likely wemux sessions are shut down at the end of the day, since it's easier to start-up
- make more consistent which numbered panes are (usually) for which purposes
- make it easier to get guard up and running in a tiny column next to vim (I imagine this would be an optional configuration since not everyone uses guard, but it would encourage people to run tests more often)

To try it:
- `homesick pull`
- `homesick symlink`
- `wemux` like normal
- `[ctrl+a] + [s]` where s is for session

To Do:
- Figure out how to open a tmux window and run a 'complex' command like `rsp` (alias) or `git status` (idk?). It works for `vim` and `guard` and `rails console` just fine.
