### PR TITLE
Add git-push-up command to push and set the upstream remote

### DIFF
--- a/home/.bin/git-push-up
+++ b/home/.bin/git-push-up
@@ -1,0 +1,1 @@
+git push -u origin $(git current-branch)


### PR DESCRIPTION
This commands add `git push-up` as an option to set the upstream remote of a branch when pushing.
It's shorter than `git push -u origin $(git current-branch)`, which is exactly what it does.
see the discussion on #34 for more info.

Also here's a gif of a pushup
![WTF!?](http://i.giphy.com/l4S9MPqCOezv2.gif)
