### PR TITLE
Create Feature Script

### DIFF
--- a/home/.bin/create-feature
+++ b/home/.bin/create-feature
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+require_relative 'feature'
+
+help_text = <<-eoht
+##### create-feature #####
+
+# What it does
+This script will create a feature pivotal story and start a feature branch for
+you. All you need to do is pass a story name. It will then create the branch
+name using a slugified version of the name you passed it.
+
+It will detect who you are hitched with and add both as story owners.
+
+It won't run under the following conditions:
+* You have added but uncommitted git changes.
+* If local develop is not up to date with origin.
+
+# Setting it up
+If you want to use it, you have to add your Pivotal API Key and Pivotal
+Project ID as environment variables.
+
+You can find the your token at the bottom of the User Profile page on Pivotal,
+which you can get to by clicking your name in the top right corner.
+
+    export PIVOTAL_TOKEN="TOKEN HERE"
+    export PIVOTAL_PROJECT_ID="some_number_here"
+
+# Getting Hitched
+This script can also detect if you are "hitched" with someone using the
+hitch gem (it reads ~/.hitchrc). If you don't hitch the Pivotal card will
+be assigned to $USER (note your Pivotal user needs to match your unix user
+in this case)
+
+# Needful environment variables
+# How you'd use it
+create-feature 'Do The Needful'
+
+eoht
+
+if ARGV[0].eql?("--help")
+  puts help_text
+  exit
+end
+
+story_name = ARGV[0]
+project_id = ENV['PIVOTAL_PROJECT_ID']
+pivotal_token = ENV['PIVOTAL_TOKEN']
+
+feature = Feature.new(
+  story_name: story_name,
+  project_id: project_id,
+  pivotal_token: pivotal_token
+)
+feature.save!

--- a/home/.bin/feature.rb
+++ b/home/.bin/feature.rb
@@ -3,14 +3,14 @@ require_relative 'story'
 class Feature < Story
   def save!
     validate_environment_and_arguments!
-    validate_git_repository
+    validate_git_repository!
 
     create_feature!
   end
 
   private
 
-  def validate_git_repository
+  def validate_git_repository!
     GitRepository.new(Dir.pwd).validate_for_feature
   end
 

--- a/home/.bin/feature.rb
+++ b/home/.bin/feature.rb
@@ -11,7 +11,7 @@ class Feature < Story
   private
 
   def validate_git_repository!
-    GitRepository.new(Dir.pwd).validate_for_feature
+    GitRepository.new(Dir.pwd).validate_for_feature!
   end
 
   def create_feature!

--- a/home/.bin/feature.rb
+++ b/home/.bin/feature.rb
@@ -2,7 +2,7 @@ require_relative 'story'
 
 class Feature < Story
   def save!
-    validate_environment_and_arguments
+    validate_environment_and_arguments!
     validate_git_repository
 
     create_feature!

--- a/home/.bin/feature.rb
+++ b/home/.bin/feature.rb
@@ -1,0 +1,26 @@
+require_relative 'story'
+
+class Feature < Story
+  def save!
+    validate_environment_and_arguments
+    validate_git_repository
+
+    create_feature!
+  end
+
+  private
+
+  def validate_git_repository
+    GitRepository.new(Dir.pwd).validate_for_feature
+  end
+
+  def create_feature!
+    story = pivotal_project.create_feature(name: story_name.titleize,
+                                           owner_usernames: derive_story_owners)
+
+    puts "Your pivotal story is https://www.pivotaltracker.com/story/show/#{story.id}"
+    puts "Creating feature branch for #{story_name}"
+
+    `git flow feature start #{branch_name(story.id)}`
+  end
+end

--- a/home/.bin/git_repository.rb
+++ b/home/.bin/git_repository.rb
@@ -25,7 +25,7 @@ class GitRepository
     end
   end
 
-  def validate_for_feature
+  def validate_for_feature!
     puts "Checking for commited files"
     if has_added_files?
       raise GitError, "Please commit or stash all added files."

--- a/home/.bin/git_repository.rb
+++ b/home/.bin/git_repository.rb
@@ -8,7 +8,7 @@ class GitRepository
     @repo = find_git_repo(path_to_repo)
   end
 
-  def validate_for_hotfix
+  def validate_for_hotfix!
     puts "Checking for commited files"
     if has_added_files?
       raise GitError, "Please commit or stash all added files."

--- a/home/.bin/git_repository.rb
+++ b/home/.bin/git_repository.rb
@@ -25,6 +25,18 @@ class GitRepository
     end
   end
 
+  def validate_for_feature
+    puts "Checking for commited files"
+    if has_added_files?
+      raise GitError, "Please commit or stash all added files."
+    end
+
+    puts "Checking if develop is up to date"
+    if !develop_up_to_date?
+      raise GitError, "Please pull --rebase develop"
+    end
+  end
+
   private
 
   def has_added_files?

--- a/home/.bin/hotfix.rb
+++ b/home/.bin/hotfix.rb
@@ -3,14 +3,14 @@ require_relative 'story'
 class Hotfix < Story
   def save!
     validate_environment_and_arguments!
-    validate_git_repository
+    validate_git_repository!
 
     create_hotfix!
   end
 
   private
 
-  def validate_git_repository
+  def validate_git_repository!
     GitRepository.new(Dir.pwd).validate_for_hotfix
   end
 

--- a/home/.bin/hotfix.rb
+++ b/home/.bin/hotfix.rb
@@ -2,7 +2,7 @@ require_relative 'story'
 
 class Hotfix < Story
   def save!
-    validate_environment_and_arguments
+    validate_environment_and_arguments!
     validate_git_repository
 
     create_hotfix!

--- a/home/.bin/hotfix.rb
+++ b/home/.bin/hotfix.rb
@@ -23,8 +23,4 @@ class Hotfix < Story
 
     `git flow hotfix start #{branch_name(story.id)}`
   end
-
-  def branch_name(story_id)
-    Shellwords.shellescape("#{story_id}-#{story_name.parameterize}")
-  end
 end

--- a/home/.bin/hotfix.rb
+++ b/home/.bin/hotfix.rb
@@ -21,10 +21,10 @@ class Hotfix < Story
     puts "Your pivotal story is https://www.pivotaltracker.com/story/show/#{story.id}"
     puts "Creating hotfix branch for #{story_name}"
 
-    `git flow hotfix start #{create_hotfix_name(story.id)}`
+    `git flow hotfix start #{branch_name(story.id)}`
   end
 
-  def create_hotfix_name(story_id)
+  def branch_name(story_id)
     Shellwords.shellescape("#{story_id}-#{story_name.parameterize}")
   end
 end

--- a/home/.bin/hotfix.rb
+++ b/home/.bin/hotfix.rb
@@ -11,7 +11,7 @@ class Hotfix < Story
   private
 
   def validate_git_repository!
-    GitRepository.new(Dir.pwd).validate_for_hotfix
+    GitRepository.new(Dir.pwd).validate_for_hotfix!
   end
 
   def create_hotfix!

--- a/home/.bin/hotfix.rb
+++ b/home/.bin/hotfix.rb
@@ -21,8 +21,7 @@ class Hotfix < Story
     puts "Your pivotal story is https://www.pivotaltracker.com/story/show/#{story.id}"
     puts "Creating hotfix branch for #{story_name}"
 
-    escaped_hotfix_name = create_hotfix_name(story.id)
-    `git flow hotfix start #{escaped_hotfix_name}`
+    `git flow hotfix start #{create_hotfix_name(story.id)}`
   end
 
   def create_hotfix_name(story_id)

--- a/home/.bin/pivotal_project.rb
+++ b/home/.bin/pivotal_project.rb
@@ -15,6 +15,15 @@ class PivotalProject
                          owner_ids: story_owner_ids)
   end
 
+  def create_feature(options)
+    story_owner_ids = find_users(options[:owner_usernames]).map(&:id)
+    project.create_story(name: options[:name],
+                         story_type: 'feature',
+                         current_state: 'started',
+                         estimate: 0,
+                         owner_ids: story_owner_ids)
+  end
+
   private
 
   attr_reader :project

--- a/home/.bin/story.rb
+++ b/home/.bin/story.rb
@@ -1,0 +1,48 @@
+require 'shellwords'
+require 'yaml'
+require 'active_support'
+require_relative 'git_repository'
+require_relative 'pivotal_project'
+
+class Story
+  def initialize(story_name:, project_id:, pivotal_token:)
+    @story_name = story_name
+    @project_id = project_id
+    @pivotal_token = pivotal_token
+  end
+
+  private
+
+  attr_reader :story_name, :project_id, :pivotal_token
+
+  def validate_environment_and_arguments
+    if env_variable_undefined?(story_name)
+      raise ArgumentError, "please pass a pivotal story name"
+    end
+
+    if env_variable_undefined?(project_id)
+      raise ArgumentError, "You need to populate the PIVOTAL_PROJECT_ID environment variable"
+    end
+
+    if env_variable_undefined?(pivotal_token)
+      raise ArgumentError, "You need to populate the PIVOTAL_TOKEN environment variable"
+    end
+  end
+
+  def env_variable_undefined?(variable)
+    variable.nil? || variable.empty?
+  end
+
+  def pivotal_project
+    PivotalProject.new(pivotal_token, project_id)
+  end
+
+  def derive_story_owners
+    hitch_config = YAML.load_file("#{ENV['HOME']}/.hitchrc")
+    if hitch_config[:current_pair].empty?
+      Array(ENV['USER'])
+    else
+      hitch_config[:current_pair]
+    end
+  end
+end

--- a/home/.bin/story.rb
+++ b/home/.bin/story.rb
@@ -45,4 +45,8 @@ class Story
       hitch_config[:current_pair]
     end
   end
+
+  def branch_name(story_id)
+    Shellwords.shellescape("#{story_id}-#{story_name.parameterize}")
+  end
 end

--- a/home/.bin/story.rb
+++ b/home/.bin/story.rb
@@ -15,7 +15,7 @@ class Story
 
   attr_reader :story_name, :project_id, :pivotal_token
 
-  def validate_environment_and_arguments
+  def validate_environment_and_arguments!
     if env_variable_undefined?(story_name)
       raise ArgumentError, "please pass a pivotal story name"
     end


### PR DESCRIPTION
This branch adds a create feature script that is very similar to the create hotfix one. It adds a feature story with 0 points based on the name you pass it. I also did a series of refactors so that I could easily drop in the new script and corresponding logic.

This script was built under similar assumptions as the hotfix one: minimum configuration/arguments necessary, sensible base-line defaults. So this does not let you pass custom points for stories or even tags, just like the hotfix one doesn't let you add tags either. In the future, if we want both of these scripts to let us add more options, I would want us to move to Thor to better handle that. http://whatisthor.com/
