### PR TITLE
If we're using system ruby, display "system" in the rvm-prompt area

### DIFF
--- a/home/.oh-my-zsh-custom/continuity.zsh-theme
+++ b/home/.oh-my-zsh-custom/continuity.zsh-theme
@@ -4,7 +4,7 @@ local return_code="%(?..%{$fg[red]%}%? ↵%{$reset_color%})"
 local user_host='%{$terminfo[bold]$fg[green]%}%n@%m%{$reset_color%}'
 local current_dir='%{$terminfo[bold]$fg[blue]%} %~%{$reset_color%}'
 if hash rvm-prompt 2>/dev/null; then
-  local rvm_ruby='%{$fg[red]%}‹$(rvm-prompt i v p g)›%{$reset_color%}'
+  local rvm_ruby='%{$fg[red]%}‹$(rvm-prompt s i v p g)›%{$reset_color%}'
 fi
 local git_branch='$(git_prompt_info)%{$reset_color%}'
 


### PR DESCRIPTION
One character PR FTW!

If you were in a project that used `system` ruby, say in our puppet repo, then you might see this in your shell prompt:
![screen shot 2015-11-17 at 3 13 46 pm](https://cloud.githubusercontent.com/assets/618499/11223434/e7fb5bf0-8d3d-11e5-9b70-1c01e6b8bec6.png)

Now you'll see this:
![screen shot 2015-11-17 at 3 13 03 pm](https://cloud.githubusercontent.com/assets/618499/11223440/ee3034c8-8d3d-11e5-8926-cecf36951069.png)

:microphone: :droplet: 
