### PR TITLE
Add global gitignore

### DIFF
--- a/home/.gitconfig.d/gitignore
+++ b/home/.gitconfig.d/gitignore
@@ -1,0 +1,19 @@
+## MAC OS
+.DS_Store
+Thumbs.db
+
+## TEXTMATE
+*.tmproj
+tmtags
+
+## EMACS
+*~
+\#*
+.\#*
+
+## VIM
+*.sw[nop]
+
+## RUBYMINE
+.idea/**/*
+.idea/

--- a/home/.gitconfig.d/shared
+++ b/home/.gitconfig.d/shared
@@ -16,6 +16,7 @@
   pager = "less -F -X"
   editor = /usr/bin/vim
   preloadindex = true
+  excludesfile = ~/.gitconfig.d/gitignore
 [merge]
   tool = /usr/bin/vimdiff
 [push]


### PR DESCRIPTION
This ignores files that no one should be committing to a shared project, like `.DS_Store` on OSX.  They can still be added manually if there's a good reason.
