### PR TITLE
Allow user overrides for tmux config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ home/.vim/.netrwhist
 home/.gitconfig.d/user
 home/.gitconfig.d/local
 home/.tmux/resurrect/
+home/.tmux/user.conf

--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -97,5 +97,7 @@ set -g @resurrect-processes '"~rails server" "~rails console" "git log" "git dif
 # Restore vim sessions
 set -g @resurrect-strategy-vim 'session'
 
+source-file "$HOME/.tmux/user.conf"
+
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -146,6 +146,11 @@ if [ -d ~/.zsh ]; then
   done
 fi
 
+# Prevent warnings if the user has not set up a tmux user.conf file
+if [ ! -f "$HOME/.tmux/user.conf" ]; then
+  touch $HOME/.tmux/user.conf
+fi
+
 # RVM is a silly thing. This fixes tmux not loading gemset
 # http://stackoverflow.com/a/6097090/3010499
 cd .


### PR DESCRIPTION
I personally have never been able to get used to this setting:

```
# Renumber windows when one is deleted
set -g renumber-windows on
```

However, I recognize that a number of people prefer it and that I am probably in the minority.  This pull request (hopefully) allows for the best of both worlds by allowing overrides in a `~/.tmux/user.conf` file. For example, that file could contain:

```
set -g renumber-windows off
```
