### PR TITLE
Make ssh_auth_sock optional

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -3,16 +3,6 @@ source-file "$HOME/.vi-everywhere/tmux.conf"
 ## Below here added by jnimety for tmux color scheme
 set -g default-terminal "screen-256color"
 
-# For ssh to work add the following to ~/.ssh/rc
-#
-# #!/bin/bash
-# if test "$SSH_AUTH_SOCK" ; then
-#   ln -sf $SSH_AUTH_SOCK ~/.ssh/ssh_auth_sock
-# fi
-
-set -g update-environment "DISPLAY SSH_ASKPASS SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY"
-set-environment -g 'SSH_AUTH_SOCK' ~/.ssh/ssh_auth_sock
-
 set -g history-limit 10000
 
 set-option -g status-interval 5

--- a/home/.tmux/ssh_auth_sock.conf
+++ b/home/.tmux/ssh_auth_sock.conf
@@ -1,0 +1,13 @@
+# For ssh to work add the following to ~/.ssh/rc
+#
+#     #!/bin/bash
+#     if test "$SSH_AUTH_SOCK" ; then
+#       ln -sf $SSH_AUTH_SOCK ~/.ssh/ssh_auth_sock
+#     fi
+#
+# And add the following to ~/.tmux/user.conf
+#
+#     source-file "$HOME/.tmux/ssh_auth_sock.conf"
+
+set -g update-environment "DISPLAY SSH_ASKPASS SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY"
+set-environment -g 'SSH_AUTH_SOCK' ~/.ssh/ssh_auth_sock


### PR DESCRIPTION
This pull request moves the `ssh_auth_sock` config into a separate `tmux` config file that can be included in `user.conf` if the user needs it.  This makes the default configuration appropriate for local development, but still allows for the previous behavior if the user is using a remote server and needing to SSH to other resources (e.g. GitHub).

**Please note:** this means that @danbernier and @jnimety will need to add this line to their `~/.tmux/user.conf`:

```
source-file "$HOME/.tmux/ssh_auth_sock.conf"
```

This should resolve [@treznick's comment](https://github.com/ContinuityControl/dotfiles/issues/50#issuecomment-222540832).  Worth noting: while I can see that this file is being sourced correctly, it's hard to completely test on my end.
