### PR TITLE
Review Feature: for when you need to look over a branch from start to finish

### DIFF
--- a/home/.bin/git-feature-review
+++ b/home/.bin/git-feature-review
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+git_flow_exists() {
+  command -v git-flow >/dev/null 2>&1
+}
+
+git_flow_initialized() {
+  git config gitflow.branch.develop && git config gitflow.branch.master
+}
+
+if git_flow_exists && git_flow_initialized; then
+  git log -p $(git config gitflow.branch.develop)..HEAD --reverse
+else
+  echo 'You need to have git-flow installed and initialized to run this command'
+fi

--- a/home/.bin/git-feature-review
+++ b/home/.bin/git-feature-review
@@ -11,5 +11,5 @@ git_flow_initialized() {
 if git_flow_exists && git_flow_initialized; then
   git log -p $(git config gitflow.branch.develop)..HEAD --reverse
 else
-  echo 'You need to have git-flow installed and initialized to run this command'
+  echo 'You need to have git-flow installed and initialized to run this command' 1>&2
 fi

--- a/home/.gitconfig.d/shared
+++ b/home/.gitconfig.d/shared
@@ -8,7 +8,7 @@
   lp = log --oneline --graph --color
   dfw = diff --word-diff=color
   nudge = push --force-with-lease
-  review-feature = log -p develop..HEAD --reverse
+  review-feature = log -p $(git config gitflow.branch.develop)..HEAD --reverse
 [color]
   status = true
   diff = true

--- a/home/.gitconfig.d/shared
+++ b/home/.gitconfig.d/shared
@@ -8,6 +8,7 @@
   lp = log --oneline --graph --color
   dfw = diff --word-diff=color
   nudge = push --force-with-lease
+  review-feature = log -p develop..HEAD --reverse
 [color]
   status = true
   diff = true

--- a/home/.gitconfig.d/shared
+++ b/home/.gitconfig.d/shared
@@ -8,13 +8,6 @@
   lp = log --oneline --graph --color
   dfw = diff --word-diff=color
   nudge = push --force-with-lease
-  review-feature = "!f() { \
-                           if hash git-flow 2>/dev/null; then \
-                             git log -p $(git config gitflow.branch.develop)..HEAD --reverse \
-                           else \
-                             echo 'You need to have git-flow installed to run this command'\
-                           fi \
-                    }"
 [color]
   status = true
   diff = true

--- a/home/.gitconfig.d/shared
+++ b/home/.gitconfig.d/shared
@@ -8,7 +8,13 @@
   lp = log --oneline --graph --color
   dfw = diff --word-diff=color
   nudge = push --force-with-lease
-  review-feature = log -p $(git config gitflow.branch.develop)..HEAD --reverse
+  review-feature = "!f() { \
+                           if hash git-flow 2>/dev/null; then \
+                             git log -p $(git config gitflow.branch.develop)..HEAD --reverse \
+                           else \
+                             echo 'You need to have git-flow installed to run this command'\
+                           fi \
+                    }"
 [color]
   status = true
   diff = true


### PR DESCRIPTION
This PR adds the `review-feature` alias for `git log -p develop..HEAD --reverse`

There are a few assumptions here for this to work:
1. you've got a branch called `develop`
2. you want to see diff changes and not just a list of commits in reverse order
   - (This one's fairly defensible, because if you just want commits, you can do `git cherry -v develop`)
