### PR TITLE
git delete-merged

### DIFF
--- a/home/.bin/git-delete-merged
+++ b/home/.bin/git-delete-merged
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+git_flow_exists() {
+  command -v git-flow >/dev/null 2>&1
+}
+
+git_flow_initialized() {
+  git config gitflow.branch.develop && git config gitflow.branch.master
+}
+
+if git_flow_exists && git_flow_initialized; then
+  git branch -d $(git branch --merged | grep -v $(git config gitflow.branch.develop))
+else
+  echo 'You need to have git-flow installed and initialized to run this command' 1>&2
+fi
+

--- a/home/.gitconfig.d/shared
+++ b/home/.gitconfig.d/shared
@@ -8,7 +8,6 @@
   lp = log --oneline --graph --color
   dfw = diff --word-diff=color
   nudge = push --force-with-lease
-  delete-merged = branch -d $(git branch --merged | grep -v $(git config gitflow.branch.develop))
 [color]
   status = true
   diff = true

--- a/home/.gitconfig.d/shared
+++ b/home/.gitconfig.d/shared
@@ -8,7 +8,7 @@
   lp = log --oneline --graph --color
   dfw = diff --word-diff=color
   nudge = push --force-with-lease
-  delete-merged = branch -d $(git branch --merged | grep -v develop)
+  delete-merged = branch -d $(git branch --merged | grep -v $(git config gitflow.branch.develop))
 [color]
   status = true
   diff = true

--- a/home/.gitconfig.d/shared
+++ b/home/.gitconfig.d/shared
@@ -8,6 +8,7 @@
   lp = log --oneline --graph --color
   dfw = diff --word-diff=color
   nudge = push --force-with-lease
+  delete-merged = branch -d $(git branch --merged | grep -v develop)
 [color]
   status = true
   diff = true


### PR DESCRIPTION
This PR adds `git delete-merged`, which will delete any branches that have been merged onto `develop`, or whatever you call that branch

It will bail if `git flow` doesn't exist, and it hasn't been run in the current repo
