### PR TITLE
Switch default foldmethod to index from syntax

### DIFF
--- a/home/.vimrc
+++ b/home/.vimrc
@@ -186,8 +186,7 @@ map <leader>= gg=G''
 " source: https://medium.com/a-tiny-piece-of-vim/making-ctrlp-vim-load-100x-faster-7a722fae7df6
 let g:ctrlp_user_command = ['.git/', 'git --git-dir=%s/.git ls-files -oc --exclude-standard']
 
-" syntax is frequently the most useful foldmethod
-set foldmethod=syntax
+set foldmethod=indent
 " foldevalstart approximates a 'don't automatically fold everything when a file is
 " opened' setting
 set foldlevelstart=99


### PR DESCRIPTION
The syntax foldmethod causes slows down vim considerably, since it has
to parse the entire file as its loading it in to detect where the folds
are. The indent foldmethod gives us much of the same benefits without
the massive slowdown.

There are perhaps other ways to solve this problem that involve keeping
the syntax foldmethod, but for now, this feels like the cleanest
approach to make our dotfiles great again as fast as possible (:troll:).
