### PR TITLE
Add swift.vim package for swift highlighting and linting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,3 +124,6 @@
 [submodule "home/.vim/bundle/vim-mkdir"]
 	path = home/.vim/bundle/vim-mkdir
 	url = https://github.com/pbrisbin/vim-mkdir.git
+[submodule "home/.vim/bundle/swift.vim"]
+	path = home/.vim/bundle/swift.vim
+	url = git@github.com:keith/swift.vim.git


### PR DESCRIPTION
Now that I'm working on iOS, it's nice to have Swift syntax highlighting when I
need to peek at a file from the command line.

I have only enabled linting in my local .vimrc, since not everyone needs to be
running this syntax checker.  I'm of course happy to include it in our shared
.vimrc if we'd like.