### PR TITLE
Add `noglob` to our git alias

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -89,7 +89,7 @@ doge() {
   "
 }
 #ignore obnoxious stuff
-alias git='nocorrect git'
+alias git='nocorrect noglob git'
 alias rake='noglob rake'
 # Add the following to your ~/.bashrc or ~/.zshrc
 #


### PR DESCRIPTION
I have been creating a lot of branches with a pound sign in them because
it is the cleanest way to use gitflow and github issues together (i.e.
`feature/#123-my-feature`).

Adding noglob means that I don't have to put quotes around the branch
name or escape it.