### PR TITLE
Move .vimrc.local to the end of the vimrc file.

### DIFF
--- a/home/.vimrc
+++ b/home/.vimrc
@@ -195,9 +195,10 @@ set foldlevelstart=99
 " https://github.com/elzr/vim-json#common-problems
 let g:vim_json_syntax_conceal = 0
 
+runtime! macros/matchit.vim
+
 " putting this here so users can override anything specified above
 if filereadable(glob("~/.vimrc.local"))
   source ~/.vimrc.local
 endif
 
-runtime! macros/matchit.vim

--- a/home/.vimrc
+++ b/home/.vimrc
@@ -108,10 +108,6 @@ nmap <Leader>let Ilet(:<esc>ea)<esc>f=r{A }<esc>
 " Select some ruby, comma-"var", and it'll extract a local variable.
 vmap <Leader>var cyour_variable<esc>Oyour_variable = <esc>p0*
 
-if filereadable(glob("~/.vimrc.local"))
-  source ~/.vimrc.local
-endif
-
 vmap <Leader>z :call I18nTranslateString()<CR>
 
 " Replace double quotes with single quotes on the current line.
@@ -198,5 +194,10 @@ set foldlevelstart=99
 " don't hide quoting in json files
 " https://github.com/elzr/vim-json#common-problems
 let g:vim_json_syntax_conceal = 0
+
+" putting this here so users can override anything specified above
+if filereadable(glob("~/.vimrc.local"))
+  source ~/.vimrc.local
+endif
 
 runtime! macros/matchit.vim


### PR DESCRIPTION
This allows users to have last say in the vim config allowing them to
override already set settings. The old location loaded before most of
the vim setup.