### PR TITLE
Ignore ~/.vim/backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ home/.gitconfig.d/local
 home/.tmux/resurrect/
 home/.tmux/user.conf
 home/.vim/spell
+home/.vim/backup


### PR DESCRIPTION
[We set this here](https://github.com/ContinuityControl/dotfiles/blob/bcd4b879815216009ea6529b185ae5216b4c3922/home/.vimrc#L25-L26).

I had this set locally so I assume it came up at some point.  Seemed best to share.