### PR TITLE
Fix broken GitGutter aliases

### DIFF
--- a/home/.vimrc
+++ b/home/.vimrc
@@ -243,8 +243,8 @@ let g:ale_fix_on_save = 1
 " gitgutter: make the gutter always show, so it doesn't shift
 set signcolumn=yes
 " aliases for gitgutter
-nmap ]h <Plug>GitGutterNextHunk
-nmap [h <Plug>GitGutterPrevHunk
+nmap ]h <Plug>(GitGutterNextHunk)
+nmap [h <Plug>(GitGutterPrevHunk)
 
 " Re-indent the whole file and go back to where you were
 map <leader>= gg=G''


### PR DESCRIPTION
Fixes #85

> When executing  `[h` and `]h`:
>
> ```
> vim-gitgutter: please change your map <Plug>GitGutterNextHunk to
> <Plug>(GitGutterNextHunk)
> ```
>
> Simple to fix.  I may have a PR soon.