### PR TITLE
more zsh tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ home/.vim/spell
 home/.vim/backup
 home/.vim/plugged
 home/.vim/local
+home/.oh-my-zsh-custom/*
+!home/.oh-my-zsh-custom/continuity.zsh-theme

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -4,8 +4,6 @@ export ZSH_CUSTOM=$HOME/.oh-my-zsh-custom
 export ZSH_THEME="continuity"
 plugins=(git git-flow rails ruby osx gem vi-mode rvm bundler)
 
-source $ZSH/oh-my-zsh.sh
-
 export LC_ALL=en_US.UTF-8
 
 #disable ctrl-s/suspension
@@ -137,6 +135,7 @@ fi
 if [ ! -f "$HOME/.tmux/user.conf" ]; then
   touch $HOME/.tmux/user.conf
 fi
+source $ZSH/oh-my-zsh.sh
 
 # RVM is a silly thing. This fixes tmux not loading gemset
 # http://stackoverflow.com/a/6097090/3010499


### PR DESCRIPTION
This PR allows more customization of the oh-my-zsh configuration.

Using a `~/.zsh/local.zsh` file you can do the following:
```
export ZSH_THEME=dracula
export ZSH_DISABLE_COMPFIX=true
unset plugins
plugins=(git osx vi-mode)
```
if you don't want to use the continuity theme

this also gitignores anything that's not the continuity theme in the `~/.oh-my-zsh-custom` directory