### PR TITLE
configurable rvm

### DIFF
--- a/home/.bash/hitch.sh
+++ b/home/.bash/hitch.sh
@@ -3,7 +3,9 @@
 # Alternatively, copy/symlink this file and source in your shell.  See `hitch --setup-path`.
 
 hitch() {
-  (rvm system; command hitch "$@")
+  if [[ -s "$HOME/.rvm" ]]; then
+    (rvm system; command hitch "$@")
+  fi
   if [[ -s "$HOME/.hitch_export_authors" ]] ; then source "$HOME/.hitch_export_authors" ; fi
 }
 alias unhitch='hitch -u'

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -18,6 +18,8 @@ export PATH="$HOME/.bin:$PATH"
 
 source "$HOME/.vi-everywhere/bash.d/init.sh"
 
-PATH=$PATH:/usr/local/rvm/bin # Add RVM to PATH for scripting
+if [[ -s "$HOME/.rvm" ]]; then
+  PATH=$PATH:/usr/local/rvm/bin # Add RVM to PATH for scripting
 
-PATH=$PATH:$HOME/.rvm/bin # Add RVM to PATH for scripting
+  PATH=$PATH:$HOME/.rvm/bin # Add RVM to PATH for scripting
+fi

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -96,16 +96,20 @@ alias rake='noglob rake'
 # Alternatively, copy/symlink this file and source in your shell.  See `hitch --setup-path`.
 
 hitch() {
-  (rvm system; command hitch "$@")
+  if [[ -s "$HOME/.rvm" ]]; then
+    (rvm system; command hitch "$@")
+  fi
   if [[ -s "$HOME/.hitch_export_authors" ]] ; then source "$HOME/.hitch_export_authors" ; fi
 }
 alias unhitch='hitch -u'
 alias vi='vim'
 alias openwork='vim -p $(git ls-files -m) $(git ls-files --others --exclude-standard)'
 
-PATH=$PATH:$HOME/.rvm/bin # Add RVM to PATH for scripting
-PATH=$PATH:$HOME/bin # Make personal scripts available
-PATH=$PATH:$HOME/.bin # Make dotfiles scripts available
+if [[ -s "$HOME/.rvm" ]]; then
+  PATH=$PATH:$HOME/.rvm/bin # Add RVM to PATH for scripting
+  PATH=$PATH:$HOME/bin # Make personal scripts available
+  PATH=$PATH:$HOME/.bin # Make dotfiles scripts available
+fi
 
 # tell nokogiri to use sysem libraries instead of compiling packaged libs
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=1
@@ -140,4 +144,6 @@ fi
 
 # RVM is a silly thing. This fixes tmux not loading gemset
 # http://stackoverflow.com/a/6097090/3010499
-cd .
+if [[ -s "$HOME/.rvm" ]]; then
+  cd .
+fi


### PR DESCRIPTION
This PR gates references to rvm that aren't already configurable in a test for the presence of `$HOME/.rvm`